### PR TITLE
Add pyproject.toml to make pxethiefy installable using common python project managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 ## Directories
 venv/
 __pycache__/
+.vscode/
+poetry.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ## Directories
 venv/
+__pycache__/

--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ $:> pipx ensurepath
 Then install `pxethiefy` using pipx:
 ```sh
 $:> pipx install git+https://github.com/csandker/pxethiefy
-$:> sudo ln -s ~/.local/bin/pxethiefy /usr/local/sbin/pxethiefy
+$:> sudo ln -s ~/.local/bin/pxethiefy /usr/local/sbin/pxethiefy     # Make pxethiefy available for sudo users
 
 ## You can now run pxethiefy as follows
 $:> sudo pxethiefy -h

--- a/Readme.md
+++ b/Readme.md
@@ -10,6 +10,7 @@ This tool is a byproduct of SCCM research, which can be found in this blog: [htt
 
 ## Install 
 
+#### Using virtualenv
 ```sh
 $:> virtualenv -p python3 venv
 $:> source venv/bin/activate
@@ -23,6 +24,25 @@ $:> python3 -m pip install -r requirements.txt
 $:> sudo setcap CAP_NET_RAW=+eip /usr/bin/python3.8 ## change with your python3 version --> run ls -lah /usr/bin/python3* to check symlinks
 $:> python3 pxethiefy.py -h
 ```
+
+#### Using pipx
+
+Install pipx as per installation instructions: [https://pipx.pypa.io/stable/how-to/install-pipx/](https://pipx.pypa.io/stable/how-to/install-pipx/)
+Make sure that pipx is in your PATH:
+```sh
+$:> pipx ensurepath
+## Now restart your terminal or do "source ~/.bashrc" (or the equivalent for your shell) to update the PATH variable
+```
+
+Then install `pxethiefy` using pipx:
+```sh
+$:> pipx install git+https://github.com/csandker/pxethiefy
+$:> sudo ln -s ~/.local/bin/pxethiefy /usr/local/sbin/pxethiefy
+
+## You can now run pxethiefy as follows
+$:> sudo pxethiefy -h
+```
+
 
 ## Usage
 

--- a/pxethiefy.py
+++ b/pxethiefy.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
 
+import importlib
 import sys
 import argparse
 import binascii
@@ -15,7 +16,6 @@ import tftpy
 from threading import Thread
 from time import sleep
 
-gVersion = "0.0.2"
 ## --------------------------------------------------------- ##
 
 MSG_TYPE_NOCOLOR = ""
@@ -376,7 +376,7 @@ def print_banner():
    \ \__\  /  /\   \    \ \_______\  \ \__\ \ \__\ \__\ \__\ \_______\ \__\__/  / /    
     \|__| /__/ /\ __\    \|_______|   \|__|  \|__|\|__|\|__|\|_______|\|__|\___/ /     
           |__|/ \|__|                                                     \|___|/      
-                                                                                       v.{gVersion}
+                                                                                       v.{importlib.metadata.version("pxethiefy")}
                                                 Based on the original PXEThief by MWR-CyberSec
                                                      https://github.com/MWR-CyberSec/PXEThief/
 """)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "pxethiefy"
+version = "0.0.2"
+description = "pxethiefy is a tool to enumerate PXE boot media provided from an SCCM server in a target network by broadcasting for PXE servers, requesting offered boot media and trying to decrypt it."
+authors = [
+    {name = "Carsten Sandker",email = "carsten.sandker@googlemail.com"}
+]
+requires-python = ">=3.11,<4"
+readme = "Readme.md"
+dependencies = [
+    "scapy (>=2.4.5)",
+    "tftpy (>=0.8.7,<0.9.0)",
+    "pycryptodome (>=3.14.1)",
+    "lxml (>=4.9.1)"
+]
+
+[project.urls]
+homepage = "https://github.com/csandker/pxethiefy"
+repository = "https://github.com/csandker/pxethiefy"
+
+[project.scripts]
+pxethiefy = "pxethiefy:main"
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Hi and thanks for your work!

As with other python tooling it is very convenient to be able to install and use them with pipx/poetry/uv. This requires a pyproject.toml file tho. I went ahead and created one, updated the installation instructions to include pipx installation instructions and updated the main script to use the version number from the pyproject.toml file (so if you bump versions later on these are automatically updated in the script as well).

Hope you find the changes convenient as well. If you want me to change anything let me know!

Working example (installing with pipx from the local directory):
<img width="1055" height="734" alt="image" src="https://github.com/user-attachments/assets/470891a8-c7ea-4ce8-8c68-9d9244cc74cf" />
